### PR TITLE
Fixed some typos in research/index.html

### DIFF
--- a/research/index.html
+++ b/research/index.html
@@ -74,7 +74,7 @@
                 <h1>Research</h1>
                 <p>At Arizona State University, I lead the Sonoran Visualization Laboratory (SVL). The SVL researches data visualization, human-computer interaction, augmented/virtual reality, and data science. In our group, we develop novel designs, algorithms, statistical models, and techniques to support analysis and decision making for complex data. We regularly collaborate with experts across a range of domains, including medical physicians, sociologists, power systems engineers, genomocists, security experts, and more. Current research projects are sponsored by ASU, Phoenix Children’s Hospital, and NSF.</p>
 
-                <p>Several of our current research topics and areas of interest are listed below, though we also work broadly in visualization and machine learning spaces. If you are interested in becoming a collaboratior with the SVL to better understand your data or increase productivity, feel free to <a href="mailto:cbryan16@asu.edu" class="link-danger">email</a> and we can schedule a meeting to discuss further.</p>
+                <p>Several of our current research topics and areas of interest are listed below, though we also work broadly in visualization and machine learning spaces. If you are interested in becoming a collaborator with the SVL to better understand your data or increase productivity, feel free to <a href="mailto:cbryan16@asu.edu" class="link-danger">email</a> and we can schedule a meeting to discuss further.</p>
 
                 <hr>
                 <div class='row'>
@@ -85,7 +85,7 @@
                         <img class="rounded shadow img-fluid border" src="/assets/img_papers/mishra2022news.png" data-holder-rendered="true">
                     </div>
                     <div class='col-8'>
-                        We develop advanced interfaces and visualization techniques to enable new ways to explore complex, high-dimensional, and heterogeneous data. Such data normally cannot be easily handled, accessed, or analyzed using current techniques and tools; we develops software stacks and user experiences that let humans analyze and reason about this data, such as lettting them more deeploy derive insights, support decision-making, and even communicate or tell stories using the data.
+                        We develop advanced interfaces and visualization techniques to enable new ways to explore complex, high-dimensional, and heterogeneous data. Such data normally cannot be easily handled, accessed, or analyzed using current techniques and tools; we develop software stacks and user experiences that let humans analyze and reason about this data, such as letting them more deploy derive insights, support decision-making, and even communicate or tell stories using the data.
                     </div>
 
                     <div class='col-12 mt-4'>
@@ -125,7 +125,7 @@
                         <img class="rounded shadow img-fluid border" src="/assets/img_papers/mishra2022why.png" data-holder-rendered="true">
                     </div>
                     <div class='col-8'>
-                        We develop interactive visualizations and user interfaces as a way to help understand the behavior of machine learning models. One way to do this is by "opening the black box" to promote trust and interpretability by understanding the inner workings of the model. Conversely, we also develop techniques and tools that support "non-expert" users, who do not necessarily have a background or expertise in AI/ML development. We also study bias and spurious correlations that can exist in datasets that are used to train machine learning models. Conversely, machine learning can be use to help guide the visualization and analysis process, such as selecting appropriate visualizations to show a user during exploration.
+                        We develop interactive visualizations and user interfaces as a way to help understand the behavior of machine learning models. One way to do this is by "opening the black box" to promote trust and interpretability by understanding the inner workings of the model. Conversely, we also develop techniques and tools that support "non-expert" users, who do not necessarily have a background or expertise in AI/ML development. We also study bias and spurious correlations that can exist in datasets that are used to train machine learning models. Conversely, machine learning can be used to help guide the visualization and analysis process, such as selecting appropriate visualizations to show a user during exploration.
                     </div>
 
                     <div class='col-12 mt-4'>


### PR DESCRIPTION
Just some minor typos: 
collaboratior -> collaborator
develops -> develop
lettting -> letting
deeploy  -> deploy
use -> used
